### PR TITLE
Don't upgrade casks when an older version already is installed

### DIFF
--- a/providers/cask.rb
+++ b/providers/cask.rb
@@ -11,7 +11,7 @@ end
 def load_current_resource
   @cask = Chef::Resource::HomebrewCask.new(new_resource.name)
   Chef::Log.debug("Checking whether #{new_resource.name} is installed")
-  @cask.casked shell_out("/usr/local/bin/brew cask list #{new_resource.name}").exitstatus == 0
+  @cask.casked shell_out("/usr/local/bin/brew cask list | grep #{new_resource.name}").exitstatus == 0
 end
 
 action :install do


### PR DESCRIPTION
`brew cask list <name>` will return with a non-zero exit code if the installed cask version is not the latest. This breaks idempotence of this resource when a newer version of a given cask available.
`brew cask list` will include older versions of casks so grepping that list will give us an actual result if it's installed or not.