### PR TITLE
Fixes #59, update cask if auto-update is true

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -19,5 +19,6 @@ suites:
     run_list:
       - recipe[build-essential]
       - recipe[homebrew::default]
+      - recipe[homebrew::cask]
       - recipe[test]
     attributes:

--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -16,7 +16,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+extend(Homebrew::Mixin)
+owner = homebrew_owner
 
 homebrew_tap 'caskroom/cask'
 
 package 'brew-cask'
+
+execute 'update homebrew cask from github' do
+  user owner
+  command '/usr/local/bin/brew upgrade brew-cask && /usr/local/bin/brew cask cleanup || true'
+  only_if { node['homebrew']['auto-update'] }
+end


### PR DESCRIPTION
Not having homebrew cask updated can lead to problems such as reported
in the following issues. The cask recipe should perform an update if
the auto-update attribute is true.

* https://github.com/caskroom/homebrew-cask/issues/7946#issuecomment-66387907
* https://github.com/opscode/pantry-chef-repo/issues/9