### PR TITLE
Fixes #52, Manage cask's install directories

### DIFF
--- a/chefignore
+++ b/chefignore
@@ -1,0 +1,56 @@
+# Put files/directories that should be ignored in this file.
+# Lines that start with '# ' are comments.
+
+## OS
+.DS_Store
+Icon?
+nohup.out
+
+## EDITORS
+\#*
+.#*
+*~
+*.sw[a-z]
+*.bak
+REVISION
+TAGS*
+tmtags
+*_flymake.*
+*_flymake
+*.tmproj
+.project
+.settings
+mkmf.log
+
+## COMPILED
+a.out
+*.o
+*.pyc
+*.so
+
+## OTHER SCM
+*/.bzr/*
+*/.hg/*
+*/.svn/*
+
+## Don't send rspecs up in cookbook
+.watchr
+.rspec
+spec/*
+spec/fixtures/*
+features/*
+
+## SCM
+.gitignore
+
+# Berkshelf
+Berksfile
+Berksfile.lock
+cookbooks/*
+
+# Vagrant
+.vagrant
+
+# test-kitchen
+.kitchen
+.kitchen*.yml*

--- a/recipes/cask.rb
+++ b/recipes/cask.rb
@@ -16,15 +16,24 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-extend(Homebrew::Mixin)
-owner = homebrew_owner
+Chef::Resource.send(:include, Homebrew::Mixin)
 
 homebrew_tap 'caskroom/cask'
 
 package 'brew-cask'
 
 execute 'update homebrew cask from github' do
-  user owner
+  user homebrew_owner
   command '/usr/local/bin/brew upgrade brew-cask && /usr/local/bin/brew cask cleanup || true'
   only_if { node['homebrew']['auto-update'] }
+end
+
+directory '/opt/homebrew-cask' do
+  owner node['homebrew']['owner'] || homebrew_owner
+  mode 00775
+end
+
+directory '/opt/homebrew-cask/Caskroom' do
+  owner node['homebrew']['owner'] || homebrew_owner
+  mode 00775
 end

--- a/spec/recipes/cask_spec.rb
+++ b/spec/recipes/cask_spec.rb
@@ -1,0 +1,61 @@
+require_relative '../spec_helper'
+
+describe 'homebrew::cask' do
+  context 'default user' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new.converge(described_recipe)
+    end
+
+    before(:each) do
+      allow_any_instance_of(Chef::Resource).to receive(:homebrew_owner).and_return('vagrant')
+    end
+
+    it 'updates homebrew cask as vagrant' do
+      expect(chef_run).to run_execute('update homebrew cask from github').with(
+        :user => 'vagrant'
+      )
+    end
+
+    it 'manages the homebrew-cask directory' do
+      expect(chef_run).to create_directory('/opt/homebrew-cask').with(
+        :user => 'vagrant',
+        :mode => 00775
+      )
+    end
+
+    it 'manages the Caskroom directory' do
+      expect(chef_run).to create_directory('/opt/homebrew-cask/Caskroom').with(
+        :user => 'vagrant',
+        :mode => 00775
+      )
+    end
+  end
+
+  context 'non-default, specified by attribute user' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new do |node|
+        node.set['homebrew']['owner'] = 'alaska'
+      end.converge(described_recipe)
+    end
+
+    it 'updates homebrew cask as alaska' do
+      expect(chef_run).to run_execute('update homebrew cask from github').with(
+        :user => 'alaska'
+      )
+    end
+
+    it 'manages the homebrew-cask directory' do
+      expect(chef_run).to create_directory('/opt/homebrew-cask').with(
+        :user => 'alaska',
+        :mode => 00775
+      )
+    end
+
+    it 'manages the Caskroom directory' do
+      expect(chef_run).to create_directory('/opt/homebrew-cask/Caskroom').with(
+        :user => 'alaska',
+        :mode => 00775
+      )
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,12 @@
+require 'chefspec'
+require 'chefspec/berkshelf'
+
+# Require all our libraries
+Dir['libraries/*.rb'].each { |f| require File.expand_path(f) }
+
+RSpec.configure do |config|
+  config.log_level = :fatal
+  config.order = 'random'
+  config.color = true
+  config.formatter = 'documentation'
+end

--- a/test/fixtures/cookbooks/test/recipes/default.rb
+++ b/test/fixtures/cookbooks/test/recipes/default.rb
@@ -1,2 +1,5 @@
 # redis is small and installs fast.
 package 'redis'
+
+# so is caffeine
+homebrew_cask 'caffeine'

--- a/test/integration/default/serverspec/default_spec.rb
+++ b/test/integration/default/serverspec/default_spec.rb
@@ -11,4 +11,10 @@ describe 'brew package for redis' do
   describe command(%Q[chef-apply -l info -e 'Chef::Log.info(Chef::Platform.find(:mac_os_x, nil)[:package])']) do
     its(:stdout) { should match('INFO: Chef::Provider::Package::Homebrew') }
   end
+
+  describe file('/opt/homebrew-cask/Caskroom/caffeine') do
+    it { should be_directory }
+    it { should be_mode 755 }
+    it { should be_owned_by 'vagrant' }
+  end
 end


### PR DESCRIPTION
This commit adds directory resources for homebrew-cask, fixing #52.

* include the Homebrew::Mixin module only on the Chef::Resource class,
making this easier to test
* Use owner attribute otherwise fallback to the homebrew owner lookup
method
* Add ChefSpec scaffolding
* Add a delightful variety of ChefSpec tests for default and
non-default users